### PR TITLE
Add workaround for fixing any accidental appearance of // in urls

### DIFF
--- a/rofi-confluence-jira.py
+++ b/rofi-confluence-jira.py
@@ -27,7 +27,7 @@ class Confluence:
         for page in pages:
             space = page['_expandable']['space'].split('/')[-1]
             title = page['title']
-            url = page['_links']['webui']
+            url = page['_links']['webui'].strip("/")
             page['url'] = f'{self.url}/{url}'
             page['label'] = f'[{space}] {title}'
         return pages


### PR DESCRIPTION
I can't open confluence links because it has `//`, I figured it probably works for you so opted for just replacing `//` in URLs as this appears to be generally helpful.

The `//` happens because

`url = page['_links']['webui']` starts with a `/` for the public atlassian confluence server.